### PR TITLE
Species Wookie spelled wrong.  It is Wookiee

### DIFF
--- a/resources/fixtures/species.json
+++ b/resources/fixtures/species.json
@@ -82,7 +82,7 @@
     "fields": {
         "edited": "2014-12-20T21:36:42.142Z",
         "classification": "mammal",
-        "name": "Wookie",
+        "name": "Wookiee",
         "designation": "sentient",
         "created": "2014-12-10T16:44:31.486Z",
         "eye_colors": "blue, green, yellow, brown, golden, red",


### PR DESCRIPTION
How can swapi get the Wookiee spelling wrong in the old fixtures? Oh the Wookieedom.